### PR TITLE
ci: fix slack notifications by sending to non-archived slack channel

### DIFF
--- a/.github/workflows/code-signing-maintenance.yml
+++ b/.github/workflows/code-signing-maintenance.yml
@@ -47,7 +47,7 @@ jobs:
             "text": "Maintenance success notice",
             "username": "Code signing maintenance bot",
             "icon_url": "https://emojiguide.org/images/emoji/1/8z8e40kucdd1.png",
-            "channel": "#team-mobile",
+            "channel": "#squad-mobile",
             "blocks": [
               {
                 "type": "section",
@@ -71,7 +71,7 @@ jobs:
             "text": "Maintenance error notice",
             "username": "Code signing maintenance bot",
             "icon_url": "https://emojiguide.org/images/emoji/1/8z8e40kucdd1.png",
-            "channel": "#team-mobile",
+            "channel": "#squad-mobile",
             "blocks": [
               {
                 "type": "section",


### PR DESCRIPTION
`#mobile-team` slack channel has been archived. Change the notifications to a non-archived slack channel. 

See [this slack message](https://customerio.slack.com/archives/C01QYDKD0SU/p1704225985713449) to learn what these slack notifications are used for. 