### PR TITLE
ci: update bundler lock file to include new CI OS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-22
@@ -218,4 +220,4 @@ DEPENDENCIES
   fastlane (~> 2.212)
 
 BUNDLED WITH
-   2.2.18
+   2.5.3


### PR DESCRIPTION
Fix latest CI run giving error:
```
Your bundle only supports platforms ["x86_64-darwin-19", "x86_64-darwin-20",
"x86_64-darwin-22", "x86_64-linux"] but your local platform is arm64-darwin-22.
Add the current platform to the lockfile with `bundle lock --add-platform
arm64-darwin-22` and try again.
```