### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/code-signing-maintenance.yml
+++ b/.github/workflows/code-signing-maintenance.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Fastlane (via ruby and Bundler) used for managing code signing files 
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
       with:
         ruby-version: '3.0' 
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -39,7 +39,7 @@ jobs:
     # Creating of code signing files via CI server on SDK code bases is not yet done. Once it is, we can add that feature. 
 
     - name: Notify team about schedule maintenance 
-      uses: slackapi/slack-github-action@v1.25.0
+      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       with:
         # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder
         payload: |
@@ -62,7 +62,7 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Notify team deleting certificates failed. Fix issue so we can get certificates deleted before expiring. 
-      uses: slackapi/slack-github-action@v1.25.0
+      uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
       if: ${{ failure() }} # only run this if any previous step failed
       with:
         # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder

--- a/.github/workflows/create-code-signing-files.yml
+++ b/.github/workflows/create-code-signing-files.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Fastlane (via ruby and Bundler) used for managing code signing files 
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
       with:
         ruby-version: '3.0' 
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/register-new-device.yml
+++ b/.github/workflows/register-new-device.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Hide the inputs values to keep them private in the logs when running this workflow
-      uses: levibostian/action-hide-sensitive-inputs@v1
+      uses: levibostian/action-hide-sensitive-inputs@80877460a95aa5e56cba23314096ef0e0a3c10c1 # v1
 
     - uses: actions/checkout@v4
 
     - name: Install Fastlane (via ruby and Bundler) used for managing code signing files 
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
       with:
         ruby-version: '3.0' 
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -51,7 +51,7 @@ jobs:
     # Below, we can now trigger other CI server jobs to make new builds of iOS apps so the new tester 
     # is able to download builds right now. 
     # - name: Create new build of Remote Habits for tester to be able to download right now 
-    #   uses: benc-uk/workflow-dispatch@v1
+    #   uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
     #   with:
     #     workflow: manual-build.yml
     #     repo: customerio/RemoteHabits-iOS


### PR DESCRIPTION
REF: [DX-516](https://linear.app/customerio/issue/DX-516/update-all-github-action-libraries-to-use-sha-instead-of-version) Pins GitHub Actions as part of DX-516.