### PR TITLE
chore(deps): resolve 3rd-party vulnerabilities (MBL-1689)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,9 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
 
+# Security pins for transitive deps (MBL-1689)
+gem "faraday", "1.10.5"
+gem "aws-sdk-s3", "1.208.0"
+gem "rexml", "3.4.2"
+
 gem "fastlane", "~> 2.212"


### PR DESCRIPTION
## Summary

Addresses [MBL-1689](https://linear.app/customerio/issue/MBL-1689) — Fix 3rd-party vulnerabilities (Non-Breaking) in `apple-code-signing`.

Pins fastlane's transitive Ruby gem deps to patched versions per Socket advisories.

| Package | From | To | Advisory |
|---|---|---|---|
| faraday | 1.10.4 | **1.10.5** | GHSA-33mh-2634-fwr2 (CVE-2026-25765) |
| aws-sdk-s3 | 1.189.1 | **1.208.0** | GHSA-2xgq-q749-89fq (CVE-2025-14762) |
| rexml | 3.4.1 | **3.4.2** | GHSA-c2f4-jgmc-q2r5 (CVE-2025-58767) |

### Notes

- Manifest-only change (Gemfile). `Gemfile.lock` will be regenerated by CI.

## Test plan

- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only dependency pinning; main risk is CI/runtime breakage if `fastlane` expects different gem versions.
> 
> **Overview**
> Pins `fastlane` transitive gems in `Gemfile` to patched versions by explicitly adding `faraday` (`1.10.5`), `aws-sdk-s3` (`1.208.0`), and `rexml` (`3.4.2`) to address reported vulnerabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4562166a861cc41b56fd32f6c5018b30bc1ef12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->